### PR TITLE
Add path to openssl cert request command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ chmod 755 /config/scripts/post-config.d/install_letsencrypt.sh
 # Generate certifications which will be used
 openssl genrsa 4096 | tee /config/letsencrypt/account.key
 openssl genrsa 4096 | tee /config/letsencrypt/domain.key
-openssl req -new -sha256 -key domain.key -subj "/CN=$fqdn" | tee /config/letsencrypt/domain.csr
+openssl req -new -sha256 -key /config/letsencrypt/domain.key -subj "/CN=$fqdn" | tee /config/letsencrypt/domain.csr
 
 # Making lighttpd configurations and restarting daemon
 mkdir /config/lighttpd/


### PR DESCRIPTION
Command on line 19 fails on my EdgeRouter X. No path to the domain.key is specified, so unless the script is in the correct working directory (it probably isnt), then this command fails.
