### PR TITLE
Update to EdgeMAX 1.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Persistent Let's Encrypt with the Ubiquiti Edge Router Lite
 
 Originally by photinus
-Modified by [kaethorn](https://github.com/kaethorn/)
+Modified by [rholmboe](https://github.com/kaethorn/)
 
 Disclaimer:
 > You will be modifying some of the inner workings of your edgerouter. This could break your router. I believe the steps I outline here are generally safe, but you will be issuing commands as root and can do damage easily. Be careful.
@@ -29,7 +29,7 @@ set firewall name WAN_LOCAL rule 15 protocol tcp
 SSH into your EdgeRouter and issue following command
 
 ```
-curl https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
+curl https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
 ```
 *Important* change public.dynamic.dns.of.your.router to whatever yours is!
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Persistent Let's Encrypt with the Ubiquiti Edge Router Lite
 
 Originally by photinus
-Modified by [rholmboe](https://github.com/rholmboe/)
+Modified by [kaethorn](https://github.com/kaethorn/)
 
 Disclaimer:
 > You will be modifying some of the inner workings of your edgerouter. This could break your router. I believe the steps I outline here are generally safe, but you will be issuing commands as root and can do damage easily. Be careful.
@@ -29,7 +29,7 @@ set firewall name WAN_LOCAL rule 15 protocol tcp
 SSH into your EdgeRouter and issue following command
 
 ```
-curl https://raw.githubusercontent.com/photinus/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
+curl https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
 ```
 *Important* change public.dynamic.dns.of.your.router to whatever yours is!
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Persistent Let's Encrypt with the Ubiquiti Edge Router Lite
 
 Originally by photinus
-Modified by [rholmboe](https://github.com/kaethorn/)
+Modified by [rholmboe](https://github.com/rholmboe/)
 
 Disclaimer:
 > You will be modifying some of the inner workings of your edgerouter. This could break your router. I believe the steps I outline here are generally safe, but you will be issuing commands as root and can do damage easily. Be careful.
@@ -29,7 +29,7 @@ set firewall name WAN_LOCAL rule 15 protocol tcp
 SSH into your EdgeRouter and issue following command
 
 ```
-curl https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
+curl https://raw.githubusercontent.com/photinus/ubnt-letsencrypt/master/install.sh | sudo bash /dev/stdin public.dynamic.dns.of.your.router
 ```
 *Important* change public.dynamic.dns.of.your.router to whatever yours is!
 

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,10 @@ fqdn=$1
 cp /etc/lighttpd/server.pem /config/letsencrypt/oldcert.pem
 curl -o /config/letsencrypt/acme_tiny.py https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py
 chmod 755 /config/letsencrypt/acme_tiny.py
-curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/letsrenew.sh
+curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/letsrenew.sh
 chmod 755 /config/letsencrypt/letsrenew.sh
 ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
-curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/install_letsencrypt.sh
+curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/install_letsencrypt.sh
 chmod 755 /config/scripts/post-config.d/install_letsencrypt.sh
 
 echo "Generate keys to be used in our signed certificate"
@@ -27,7 +27,7 @@ echo "Generate keys to be used in our signed certificate"
 
 echo "Making lighttpd configurations and restarting daemon so letsencypt and verify we own this domain via .well-known/acme-challenge/"
 [ -d /config/lighttpd ] ||  mkdir /config/lighttpd/
-curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/lighttpd.conf
+curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/lighttpd.conf
 ln -sf /config/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf
 cat /var/run/lighttpd.pid | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,10 @@ fqdn=$1
 cp /etc/lighttpd/server.pem /config/letsencrypt/oldcert.pem
 curl -o /config/letsencrypt/acme_tiny.py https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py
 chmod 755 /config/letsencrypt/acme_tiny.py
-curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/letsrenew.sh
+curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/photinus/ubnt-letsencrypt/master/letsrenew.sh
 chmod 755 /config/letsencrypt/letsrenew.sh
 ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
-curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/install_letsencrypt.sh
+curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/photinus/ubnt-letsencrypt/master/install_letsencrypt.sh
 chmod 755 /config/scripts/post-config.d/install_letsencrypt.sh
 
 echo "Generate keys to be used in our signed certificate"
@@ -27,7 +27,7 @@ echo "Generate keys to be used in our signed certificate"
 
 echo "Making lighttpd configurations and restarting daemon so letsencypt and verify we own this domain via .well-known/acme-challenge/"
 [ -d /config/lighttpd ] ||  mkdir /config/lighttpd/
-curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/lighttpd.conf
+curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/photinus/ubnt-letsencrypt/master/lighttpd.conf
 ln -sf /config/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf
 cat /var/run/lighttpd.pid | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,10 @@ fqdn=$1
 cp /etc/lighttpd/server.pem /config/letsencrypt/oldcert.pem
 curl -o /config/letsencrypt/acme_tiny.py https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py
 chmod 755 /config/letsencrypt/acme_tiny.py
-curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/letsrenew.sh
+curl -o /config/letsencrypt/letsrenew.sh https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/letsrenew.sh
 chmod 755 /config/letsencrypt/letsrenew.sh
 ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
-curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/install_letsencrypt.sh
+curl -o /config/scripts/post-config.d/install_letsencrypt.sh https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/install_letsencrypt.sh
 chmod 755 /config/scripts/post-config.d/install_letsencrypt.sh
 
 echo "Generate keys to be used in our signed certificate"
@@ -27,7 +27,7 @@ echo "Generate keys to be used in our signed certificate"
 
 echo "Making lighttpd configurations and restarting daemon so letsencypt and verify we own this domain via .well-known/acme-challenge/"
 [ -d /config/lighttpd ] ||  mkdir /config/lighttpd/
-curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/rholmboe/ubnt-letsencrypt/master/lighttpd.conf
+curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/lighttpd.conf
 ln -sf /config/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf
 ps -e | grep lighttpd | awk '{print $1;}' | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ echo "Making lighttpd configurations and restarting daemon so letsencypt and ver
 [ -d /config/lighttpd ] ||  mkdir /config/lighttpd/
 curl -o /config/lighttpd/lighttpd.conf https://raw.githubusercontent.com/kaethorn/ubnt-letsencrypt/master/lighttpd.conf
 ln -sf /config/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf
-ps -e | grep lighttpd | awk '{print $1;}' | xargs kill
+cat /var/run/lighttpd.pid | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
 
 # Create acme respons directory

--- a/install_letsencrypt.sh
+++ b/install_letsencrypt.sh
@@ -7,5 +7,5 @@ ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
 cat /config/letsencrypt/signed.crt | tee /etc/lighttpd/server.pem
 cat /config/letsencrypt/domain.key | tee -a /etc/lighttpd/server.pem
 
-ps -e | grep lighttpd | awk '{print $1;}' | xargs kill
+cat /var/run/lighttpd.pid | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

--- a/letsrenew.sh
+++ b/letsrenew.sh
@@ -15,5 +15,5 @@ cat /config/letsencrypt/signed.crt > /etc/lighttpd/server.pem
 cat /config/letsencrypt/domain.key >> /etc/lighttpd/server.pem
 
 # Restarting lighttpd daemon
-ps -e | grep lighttpd | awk '{print $1;}' | xargs kill
+cat /var/run/lighttpd.pid | xargs kill
 /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -21,18 +21,13 @@ index-file.names            = ( "index.php", "index.html",
 # "~",
 url.access-deny             = ( ".inc" )
 
-static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
+static-file.exclude-extensions = ( ".php", ".pl", ".fcgi", ".py" )
 
 server.dir-listing          = "disable"
 
 include "mime.conf"
 include "conf-enabled/10-ssl.conf"
 include "conf-enabled/15-fastcgi-python.conf"
-
-url.rewrite-once = (
-        "^(/(lib|media|ws|tests|.well-known)/.*)" => "$0",
-        "^/([^\?]+)(\?(.*))?$" => "/index.php/$1?$3"
-)
 
 $HTTP["scheme"] == "http" {
   $HTTP["url"] !~ "^/.well-known/acme-challenge/*" {

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -29,14 +29,23 @@ include "mime.conf"
 include "conf-enabled/10-ssl.conf"
 include "conf-enabled/15-fastcgi-python.conf"
 
+# Enable ACME challenge by skipping HTTP to HTTPS redirect and
+# FastCGI interpretation.
 $HTTP["scheme"] == "http" {
-  $HTTP["url"] !~ "^/.well-known/acme-challenge/*" {
-    $HTTP["url"] !~ "^/index.php/error/" {
-        $HTTP["host"] =~ "^(.*)$" {
-                url.redirect = (
-                        "^(.*)$" => "https://%1$1"
-                )
-        }
+  $HTTP["url"] =~ ".well-known/acme-challenge/*" {
+    fastcgi.server = ()
+    # IPv4 redirect
+    $HTTP["host"] !~ "\[.*\]" {
+      $HTTP["host"] =~ "^([^\:]+)(\:.*)?$" {
+        url.redirect = ()
+      }
+    }
+
+    # IPv6 redirect
+    $HTTP["host"] =~ "\[.*\]" {
+      $HTTP["host"] =~ "^([^]]+)(.)(\:.*)?$" {
+        url.redirect = ()
+      }
     }
   }
 }

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -27,7 +27,7 @@ server.dir-listing          = "disable"
 
 include "mime.conf"
 include "conf-enabled/10-ssl.conf"
-include "conf-enabled/15-fastcgi-php.conf"
+include "conf-enabled/15-fastcgi-python.conf"
 
 url.rewrite-once = (
         "^(/(lib|media|ws|tests|.well-known)/.*)" => "$0",


### PR DESCRIPTION
* [x] Adjust shipped `lighttpd.conf` to EdgeMAX 1.9.7 changes.
* [x] Kill `lighttpd` by reading its PID from the configured `/var/run/lighttpd.pid` file.

I'm not sure about the curl links being used currently, but they seemed wrong. So I fixed them. Please let me know if it was intended that the install script for this repository actually downloads files from another.